### PR TITLE
Make libgmp dependency optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,9 @@ dbus = "0.2.3"
 num = "0.1.30"
 rand = "0.3.13"
 rust-crypto = "0.2.34"
-rust-gmp = "0.2.10"
+rust-gmp = { version = "0.2.10", optional = true }
+
+[features]
+default = ["gmp"]
+
+gmp = ["rust-gmp"]

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This library is feature complete but still in *experimental* stage.
 
 ### Basic Usage
 
-Requires dbus and gmp development libraries installed.
+Requires dbus and gmp development libraries installed (see [Advanced](#advanced) section if you need to disable gmp).
 
 On ubuntu, requires libdbus-1-dev and libgmp-dev.
 
@@ -74,6 +74,23 @@ fn main() {
 - SecretService: initialize dbus, create plain/encrypted session.
 - Collections: create, delete, search.
 - Items: create, delete, search, get/set secret.
+
+### Advanced
+
+It is possible to disable the dependency on `libgmp` by disabling the default
+features in your `Cargo.toml` file:
+
+    [dependencies]
+    secret-service = { version = "^0.4", default-features = false }
+
+ 
+**Note**: this will build the library without support for creating encrypted connections 
+to `dbus`, `EncryptionType::Dh` will be unavailable. 
+
+In many cases this is OK, as `dbus` encryption is primarily intended to prevent secrets
+from being swapped to disk. 
+
+Use `EncryptionType::Plain` when `gmp` is disabled.
 
 ### Todo
 

--- a/src/item.rs
+++ b/src/item.rs
@@ -481,6 +481,7 @@ mod test{
         assert_eq!(secret, b"new_test");
     }
 
+    #[cfg(feature = "gmp")]
     #[test]
     fn should_create_encrypted_item() {
         let ss = SecretService::new(EncryptionType::Dh).unwrap();
@@ -497,6 +498,8 @@ mod test{
         assert_eq!(secret, b"test_encrypted");
 
     }
+
+    #[cfg(feature = "gmp")]
     #[test]
     #[should_panic]
     fn should_not_create_encrypted_item_from_empty_secret() {
@@ -512,6 +515,7 @@ mod test{
         ).unwrap();
     }
 
+    #[cfg(feature = "gmp")]
     #[test]
     fn should_get_encrypted_secret_across_dbus_connections() {
         {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,6 +92,12 @@
 //! SecretService::new(EncryptionType::Dh).unwrap();
 //! ```
 //!
+//! EncryptionType::Dh requires the `gmp` feature to be enabled in Cargo.toml, which is the default.
+//! This requires `libgmp` to be available.
+//!
+//! When the `gmp` feature is disabled by disabling the default features in Cargo.toml,
+//! EncryptionType::Plain will be the only one available.
+//!
 //! Once the SecretService struct is initialized, it can be used to navigate to a collection.
 //! Items can also be directly searched for without getting a collection first.
 //!
@@ -194,7 +200,7 @@ use std::rc::Rc;
 ///
 /// Creating a new SecretService will also initialize dbus
 /// and negotiate a new cryptographic session
-/// (`EncryptionType::Plain` or `EncryptionType::Dh`)
+/// (`EncryptionType::Plain` or `EncryptionType::Dh`, when the `gmp` feature is enabled)
 ///
 // Interfaces are the dbus namespace for methods
 #[derive(Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,6 +146,7 @@
 
 extern crate crypto;
 extern crate dbus;
+#[cfg(feature = "gmp")]
 extern crate gmp;
 extern crate num;
 extern crate rand;

--- a/src/session.rs
+++ b/src/session.rs
@@ -38,9 +38,11 @@ use dbus::MessageItem::{
     Str,
     Variant,
 };
+#[cfg(feature = "gmp")]
 use gmp::mpz::Mpz;
 use num::bigint::BigUint;
 use rand::{Rng, OsRng};
+
 use std::rc::Rc;
 
 // for key exchange
@@ -58,6 +60,7 @@ const DH_PRIME_1024_BYTES: [u8; 128] = [
 #[derive(Debug, PartialEq)]
 pub enum EncryptionType {
     Plain,
+    #[cfg(feature = "gmp")]
     Dh,
 }
 
@@ -121,6 +124,7 @@ impl Session {
                     my_public_key: None,
                 })
             },
+            #[cfg(feature = "gmp")]
             EncryptionType::Dh => {
                 // crypto: create private and public key, send public key
                 // requires some finagling to get pow() for bigints
@@ -223,12 +227,14 @@ impl Session {
     }
 }
 
+#[cfg(feature = "gmp")]
 fn bytes_to_mpz(n: &[u8]) -> Result<Mpz, ()> {
     let bigint = BigUint::from_bytes_be(n);
     let bigint_str = bigint.to_str_radix(10);
     Mpz::from_str_radix(&bigint_str, 10)
 }
 
+#[cfg(feature = "gmp")]
 fn mpz_to_bytes(mpz: Mpz) -> Vec<u8> {
     let bigint_str = mpz.to_str_radix(10);
     let bigint = bigint_str.parse::<BigUint>().unwrap(); //TODO: turn this into a try or option?
@@ -239,6 +245,7 @@ fn mpz_to_bytes(mpz: Mpz) -> Vec<u8> {
 mod test {
     use std::rc::Rc;
     use super::*;
+    #[cfg(feature = "gmp")]
     use super::{bytes_to_mpz, mpz_to_bytes};
     use dbus::{Connection, BusType};
 
@@ -249,6 +256,7 @@ mod test {
         assert!(!session.is_encrypted());
     }
 
+    #[cfg(feature = "gmp")]
     #[test]
     fn should_create_encrypted_session() {
         let bus = Connection::get_private(BusType::Session).unwrap();
@@ -258,6 +266,7 @@ mod test {
         //assert!(false);
     }
 
+    #[cfg(feature = "gmp")]
     #[test]
     fn should_convert_bytes_to_mpz() {
         assert_eq!(bytes_to_mpz(&[1u8, 1]).unwrap(), From::<u32>::from(257));


### PR DESCRIPTION
Hi :)

I've moved the code that requires linking with` libgmp` behind a feature (but made it the default). 

This makes the Plain encryption type the only one available when `libgmp` is not available, but that's OK for many use cases, and the pseudo-TLS design in the Secret Service specification is more or less only intended for preventing secrets from being swapped to disk anyway, which can be solved in other ways.

This was needed for a few reasons:

1) Linking with `libgmp` on some Rust targets, like `x86_64-unknown-linux-musl`, requires building it separately rather than just installing the distro version, which is almost always going to be built to work with gnu `libc`. That would be fine in many cases, as it's not *that* hard to build things (and `libdbus` *also* has to be built the same way), but...

2) Linking Apache 2.0 licensed code with, and using, a LGPLv3/GPLv3 library like `libgmp` presents a licensing issue that *might* be resolvable in some cases. Dynamically linking to it may be ok if you choose to use `libgmp` under the LGPLv3 or if `libgmp` qualifies for the system library exception to the GPLv3, but that wouldn't work for a musl library/binary anyway as it would have to be statically linked.

As an aside, `libdbus` would also present these issues in some cases, but it's dual licensed under the [AFL 2.1](https://en.wikipedia.org/wiki/Academic_Free_License), which makes some things easier (static linking `libdbus` itself), and some things harder, as it is completely incompatible with the GPL so nothing else licensed under the GPL could be linked at all.