### PR TITLE
Partially removes dependency on rust-crypto

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ version = "0.4.0"
 [dependencies]
 dbus = "0.2.3"
 num = "0.1.30"
-rand = "0.3.13"
+ring = "0.12.1"
 rust-crypto = "0.2.34"
 rust-gmp = { version = "0.3", optional = true }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,7 +155,7 @@ extern crate dbus;
 #[cfg(feature = "gmp")]
 extern crate gmp;
 extern crate num;
-extern crate rand;
+extern crate ring;
 
 mod collection;
 mod error;

--- a/src/util.rs
+++ b/src/util.rs
@@ -40,7 +40,7 @@ use dbus::MessageItem::{
     Str,
     Struct,
 };
-use rand::{Rng, OsRng};
+use ring::rand::{SecureRandom, SystemRandom};
 use std::rc::Rc;
 
 #[derive(Debug, Clone)]
@@ -115,10 +115,11 @@ pub fn format_secret(session: &Session,
                     ) -> ::Result<MessageItem> {
 
     if session.is_encrypted() {
-        let mut rng = OsRng::new().unwrap();
-        let mut aes_iv = [0;16];
-        rng.fill_bytes(&mut aes_iv);
-
+        let mut aes_iv = [0; 16];
+        {
+            let rng = SystemRandom::new();
+            rng.fill(&mut aes_iv).unwrap();
+        }
         let encrypted_secret = try!(encrypt(secret, &session.get_aes_key()[..], &aes_iv));
 
         // Construct secret struct


### PR DESCRIPTION
This PR removes the dependency on rust-crypto's HKDF implementation and uses [ring::hkdf](https://briansmith.org/rustdoc/ring/hkdf/index.html) instead.
Also entirely removes dependency on rand and uses [ring::rand](https://briansmith.org/rustdoc/ring/rand/index.html) instead.

Unfortunately I have no way of verifying that this works, since I'm affected by #3, but I hope this gets the project closer to not having to rely on rust-crypto!