### PR TITLE
Replaces plain rust-crypto with patched avx2 instructions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ version = "0.4.0"
 dbus = "0.2.3"
 num = "0.1.30"
 rand = "0.3.13"
-rust-crypto = "0.2.34"
+rust-crypto = { git = 'https://github.com/awmath/rust-crypto', rev = '394c247254dbe2ac5d44483232cf335d10cf0260' }
 rust-gmp = { version = "0.3", optional = true }
 
 [features]


### PR DESCRIPTION
Originally I didn't intend on making this PR. But patching everything locally to get it working on my machine is a real pain. I would greatly appreciate it if you could merge this because it removes the requirement for AVX2 instructions, which my machine does not support. The patch is very minimal and I have only added the one specific commit as a dependency to avoid any unforeseen clashes with additions to the other repo.
If you want to look at the patch it can be found here https://github.com/awmath/rust-crypto on the _avx2_
branch.
The issue at hand was already discussed in #3