### PR TITLE
Make get_collection_* return SsError::NoResult when collection doesn't exist

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -263,11 +263,15 @@ impl SecretService {
 
         let res = try!(self.service_interface.method("ReadAlias", vec![name]));
         if let ObjectPath(ref path) = res[0] {
-            Ok(Collection::new(
-                self.bus.clone(),
-                &self.session,
-                path.clone()
-            ))
+            if &**path == "/" {
+                Err(SsError::NoResult)
+            } else {
+                Ok(Collection::new(
+                    self.bus.clone(),
+                    &self.session,
+                    path.clone()
+                ))
+            }
         } else {
             Err(SsError::Parse)
         }


### PR DESCRIPTION
See `ReadAlias` specification[1].

* [1] https://specifications.freedesktop.org/secret-service/latest/re01.html