### PR TITLE
bump dependencies where no code changes are necessary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,10 @@ repository = "https://github.com/hwchen/secret-service-rs.git"
 version = "1.1.2"
 
 [dependencies]
-aes = "0.4.0"
-block-modes = "0.5.0"
+aes = "0.6.0"
+block-modes = "0.7.0"
 dbus = "0.2.3"
-hkdf = "0.9"
+hkdf = "0.10"
 lazy_static = "1.3.0"
 num = "0.3.0"
 rand = "0.7.3"


### PR DESCRIPTION
This bumps aes, block-modes, and hkdf to allow the latest stable versions of all three. No code changes are required, this has been applied to Fedora packages for a while now and I have not seen problems.