### PR TITLE
Update dependencies to avoid cargo-audit warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,11 @@ edition = "2018"
 version = "2.0.1"
 
 [dependencies]
-aes = "0.6.0"
-block-modes = "0.7.0"
-hkdf = "0.10.0"
+aes = "0.7.0"
+block-modes = "0.8.0"
+hkdf = "0.11.0"
 lazy_static = "1.4.0"
-num = "0.3.1"
+num = "0.4.0"
 rand = "0.8.1"
 serde = { version = "1.0.118", features = ["derive"] }
 sha2 = "0.9.2"

--- a/src/ss_crypto.rs
+++ b/src/ss_crypto.rs
@@ -17,14 +17,14 @@ use crate::error::Result;
 type Aes128Cbc = Cbc<Aes128, Pkcs7>;
 
 pub fn encrypt(data: &[u8], key: &[u8], iv: &[u8]) -> Result<Vec<u8>> {
-    let cipher = Aes128Cbc::new_var(key, iv)?;
+    let cipher = Aes128Cbc::new_from_slices(key, iv)?;
     let cipher_text = cipher.encrypt_vec(data);
 
     Ok(cipher_text)
 }
 
 pub fn decrypt(encrypted_data: &[u8], key: &[u8], iv: &[u8]) -> Result<Vec<u8>> {
-    let cipher = Aes128Cbc::new_var(key, iv)?;
+    let cipher = Aes128Cbc::new_from_slices(key, iv)?;
     let decrypted = cipher.decrypt_vec(encrypted_data)?;
 
     Ok(decrypted)


### PR DESCRIPTION
Hi there,

Recently the [`aesni`](https://github.com/RustSec/advisory-db/pull/893) and [`aessoft`](https://github.com/RustSec/advisory-db/pull/895) crates were deprecated due to becoming included in the `aes` crate. This causes `cargo-audit` to complain in some cases.

This PR updates the set of `RustCrypto` dependencies in `secret-service`, and `num` for good measure to their latest versions to get rid of the deprecation warnings in project's dependency trees.

If this merges and is not inconvenient, a patch release would be great. 

Closes #30