### PR TITLE
Bump MSRV to Rust 1.51

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
         rust:
           - stable
           # MSRV
-          - 1.46.0
+          - 1.51.0
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
I was mistaken in #33 and for some reason, my local testing didn't pick up on `zbus`'s requirement for Cargo's v2 feature resolver. I suspect this is because `cargo` itself was updated, but the Rust version was on 1.46. Due to this, this crate's MSRV will need to be 1.51.