### PR TITLE
Bump MSRV to 1.54

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,8 +20,8 @@ jobs:
       matrix:
         rust:
           - stable
-          # MSRV
-          - 1.51.0
+          # MSRV, influenced by zbus.
+          - 1.54.0
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
This is required for CI to pass following the update to `zbus` 2.0.