### PR TITLE
Bump crate version to 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
-Unreleased
-- Updated dependencies where reasonable
+[2.1.0]
+- Updated dependency versions: `aes`, `block-modes`, `hkdf`, `num`, `sha2`
 - Bumped MSRV to 1.54
-- BREAKING: Updated to `zbus` 2.0. This changes error types and public path fields.
+- BREAKING: Updated to `zbus` 2.0. This changes error types and public path fields. This also addresses a security advisory in one of `zbus`'s dependencies, the `nix` crate (https://rustsec.org/advisories/RUSTSEC-2021-0119), so users should update as soon as possible.
 - BREAKING: `Error::Crypto` now contains a `&'static str` instead of a `String`.
 
 [2.0.1]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 name = "secret-service"
 repository = "https://github.com/hwchen/secret-service-rs.git"
 edition = "2018"
-version = "2.0.1"
+version = "2.1.0"
 
 [dependencies]
 # TODO: Update these when Rust 1.56 isn't so new.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ In Cargo.toml:
 
 ```
 [dependencies]
-secret-service = "2.0.0"
+secret-service = "2.1.0"
 ```
 
 If you have `cargo-extras` installed, can replace above step with the command at the prompt in your project directory:


### PR DESCRIPTION
This is essential for addressing the security vulnerability in the nix dependency, which is included by the prior version of zbus. Read more here: https://rustsec.org/advisories/RUSTSEC-2021-0119

Closes https://github.com/hwchen/secret-service-rs/issues/38 .