### PR TITLE
v2.0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 name = "secret-service"
 repository = "https://github.com/hwchen/secret-service-rs.git"
 edition = "2018"
-version = "2.0.1"
+version = "2.0.2"
 
 [dependencies]
 aes = "0.6.0"
@@ -19,7 +19,7 @@ num = "0.3.1"
 rand = "0.8.1"
 serde = { version = "1.0.118", features = ["derive"] }
 sha2 = "0.9.2"
-zbus = "1.7.0"
+zbus = "1.9.2"
 zbus_macros = "1.7.0"
 zvariant = "2.4.0"
 zvariant_derive = "2.4.0"


### PR DESCRIPTION
This version bumps the zbus dependency to a new minimum of v1.9.2.
This is important because zbus v1.9.2 depends on nix v0.20.2,
which is the first release of nix not to contain the security
vulnerability described at https://rustsec.org/advisories/RUSTSEC-2021-0119