### PR TITLE
Bump MSRV to 1.58

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
         rust:
           - stable
           # MSRV, influenced by zbus.
-          - 1.54.0
+          - 1.58.0
 
     steps:
     - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 Unreleased
 - Updated dependencies where reasonable
-- Bumped MSRV to 1.54
+- Bumped MSRV to 1.58
 - BREAKING: Updated to `zbus` 2.0. This changes error types and public path fields.
 - BREAKING: `Error::Crypto` now contains a `&'static str` instead of a `String`.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ name = "secret-service"
 repository = "https://github.com/hwchen/secret-service-rs.git"
 edition = "2018"
 version = "2.0.1"
+rust-version = "1.58.0"
 
 [dependencies]
 # TODO: Update these when Rust 1.56 isn't so new.


### PR DESCRIPTION
This is necessary to compile zbus 2.32, which fails on earlier versions.