### PR TITLE
Small changes and improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Unreleased
 - BREAKING: `Error::Crypto` now contains a `&'static str` instead of a `String`.
 - BREAKING: `SecretService::search_items` now takes a `HashMap<&str, &str>` instead of `Vec<(&str, &str)>` for the attributes.
 - BREAKING: The `SecretService::new()` method was renamed to `SecretService::connect()` to be more accurate.
+- BREAKING: `Error` is now marked as `#[non_exhaustive]` to allow for additions to be made more easily in the future.
 
 [2.0.2]
 - Increased minimum `zbus` version to 1.9.2, in order to increase the minimum version of the transitive dependency `nix` to at least 0.20.2, which is the first `nix` release to contain the fix for the security vulnerability described at https://rustsec.org/advisories/RUSTSEC-2021-0119 . A known issue with this version of `nix` is that it places an upper bound on the version of the `bitflags` dependency; if you are depending on `bitflags`, you may need to downgrade your `bitflags` version in order to upgrade to this version of `secret-service`, which you are encouraged to do in order to ensure that you are not exposed to the aforementioned `nix` vulnerability. In the long term, this will be fixed by upgrading `secret-service` to use a newer version of `zbus`, which itself depends on versions of `nix` which no longer have this restriction on `bitflags`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Unreleased
 - BREAKING: `SecretService::search_items` now takes a `HashMap<&str, &str>` instead of `Vec<(&str, &str)>` for the attributes.
 - BREAKING: The `SecretService::new()` method was renamed to `SecretService::connect()` to be more accurate.
 - BREAKING: `Error` is now marked as `#[non_exhaustive]` to allow for additions to be made more easily in the future.
+- BREAKING: Several dead error variants were pruned.
 
 [2.0.2]
 - Increased minimum `zbus` version to 1.9.2, in order to increase the minimum version of the transitive dependency `nix` to at least 0.20.2, which is the first `nix` release to contain the fix for the security vulnerability described at https://rustsec.org/advisories/RUSTSEC-2021-0119 . A known issue with this version of `nix` is that it places an upper bound on the version of the `bitflags` dependency; if you are depending on `bitflags`, you may need to downgrade your `bitflags` version in order to upgrade to this version of `secret-service`, which you are encouraged to do in order to ensure that you are not exposed to the aforementioned `nix` vulnerability. In the long term, this will be fixed by upgrading `secret-service` to use a newer version of `zbus`, which itself depends on versions of `nix` which no longer have this restriction on `bitflags`.

--- a/src/error.rs
+++ b/src/error.rs
@@ -27,6 +27,9 @@ pub enum Error {
     NoResult,
     /// An authorization prompt was dismissed, but is required to continue.
     Prompt,
+    /// A secret service provider, or a session to connect to one, was found
+    /// on the system.
+    Unavailable,
 }
 
 impl fmt::Display for Error {
@@ -39,6 +42,7 @@ impl fmt::Display for Error {
             Error::Locked => f.write_str("SS Error: object locked"),
             Error::NoResult => f.write_str("SS error: result not returned from SS API"),
             Error::Prompt => f.write_str("SS error: prompt dismissed"),
+            Error::Unavailable => f.write_str("no secret service provider or dbus session found"),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -26,6 +26,7 @@ use std::{error, fmt};
 use zbus::zvariant;
 
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum Error {
     Crypto(&'static str),
     Zbus(zbus::Error),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,8 +155,14 @@ pub struct SecretService<'a> {
 impl<'a> SecretService<'a> {
     /// Create a new `SecretService` instance.
     pub async fn connect(encryption: EncryptionType) -> Result<SecretService<'a>, Error> {
-        let conn = zbus::Connection::session().await?;
-        let service_proxy = ServiceProxy::new(&conn).await?;
+        let conn = zbus::Connection::session()
+            .await
+            .map_err(util::handle_conn_error)?;
+
+        let service_proxy = ServiceProxy::new(&conn)
+            .await
+            .map_err(util::handle_conn_error)?;
+
         let session = Session::new(&service_proxy, encryption).await?;
 
         Ok(SecretService {

--- a/src/session.rs
+++ b/src/session.rs
@@ -216,9 +216,9 @@ pub fn encrypt(data: &[u8], key: &AesKey, iv: &[u8]) -> Vec<u8> {
 pub fn decrypt(encrypted_data: &[u8], key: &AesKey, iv: &[u8]) -> Result<Vec<u8>, Error> {
     let iv = GenericArray::from_slice(iv);
     let cipher = Aes128Cbc::new_fix(key, iv);
-    let decrypted = cipher.decrypt_vec(encrypted_data)?;
-
-    Ok(decrypted)
+    cipher
+        .decrypt_vec(encrypted_data)
+        .map_err(|_| Error::Crypto("message decryption failed"))
 }
 
 #[cfg(test)]

--- a/src/util.rs
+++ b/src/util.rs
@@ -151,3 +151,11 @@ fn handle_signal(signal: Completed) -> Result<zvariant::OwnedValue, Error> {
         Ok(args.result.into())
     }
 }
+
+pub(crate) fn handle_conn_error(e: zbus::Error) -> Error {
+    match e {
+        zbus::Error::InterfaceNotFound | zbus::Error::Address(_) => Error::Unavailable,
+        zbus::Error::Io(e) if e.kind() == std::io::ErrorKind::NotFound => Error::Unavailable,
+        e => e.into(),
+    }
+}


### PR DESCRIPTION
This makes some small changes, some of which need a new release to do, including:
- Cleaning up stale error variants
- Adding new error variants and making `Error` more flexible going forward
- Improving the error message when no secret service provider is accessible on the system.