### PR TITLE
Gracefully handle decryption message decryption failures

### DIFF
--- a/src/blocking/item.rs
+++ b/src/blocking/item.rs
@@ -114,7 +114,7 @@ impl<'a> Item<'a> {
             let aes_iv = secret_struct.parameters;
 
             // decrypt
-            let decrypted_secret = decrypt(&secret, session_key, &aes_iv).unwrap();
+            let decrypted_secret = decrypt(&secret, session_key, &aes_iv)?;
 
             Ok(decrypted_secret)
         } else {

--- a/src/item.rs
+++ b/src/item.rs
@@ -121,7 +121,7 @@ impl<'a> Item<'a> {
             let aes_iv = secret_struct.parameters;
 
             // decrypt
-            let decrypted_secret = decrypt(&secret, session_key, &aes_iv).unwrap();
+            let decrypted_secret = decrypt(&secret, session_key, &aes_iv)?;
 
             Ok(decrypted_secret)
         } else {


### PR DESCRIPTION
At work, we noticed that we were seeing several crash reports whose source was calling `.unwrap()` on these decrypt operations. I'm not really sure how this is possible given that the secret should be setup and shared between the secret service dbus provider and the user of `secret-service` crate, but these arguably shouldn't be unwraps anyway.