### PR TITLE
Add running the tests via CI with gnome-keyring

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,3 +67,46 @@ jobs:
         with:
           command: fmt
           args: --all -- --check
+
+  test:
+    name: Tests
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        rust:
+          - stable
+          # MSRV, influenced by zbus.
+          - 1.60.0
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          profile: minimal
+
+      - name: Install gnome-keyring
+        run: sudo apt-get install -y gnome-keyring
+
+      - name: Start gnome-keyring
+        # run gnome-keyring with 'foobar' as password for the login keyring
+        # this will create a new login keyring and unlock it
+        # the login password doesn't matter, but the keyring must be unlocked for the tests to work
+        run: gnome-keyring-daemon --components=secrets --daemonize --unlock <<< 'foobar'
+
+      - name: Run tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          # run tests single-threaded to avoid race conditions
+          args: -- --test-threads=1
+
+      - name: Run example
+        uses: actions-rs/cargo@v1
+        with:
+          command: run
+          args: --example example

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,4 @@ zbus = { version = "3", default-features = false }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "macros"] }
+test-with = { version = "0.8", default-features = false }

--- a/src/blocking/mod.rs
+++ b/src/blocking/mod.rs
@@ -228,6 +228,7 @@ mod test {
         let _ = ss.get_any_collection().unwrap();
     }
 
+    #[test_with::no_env(GITHUB_ACTIONS)]
     #[test]
     fn should_create_and_delete_collection() {
         let ss = SecretService::connect(EncryptionType::Plain).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -378,6 +378,7 @@ mod test {
         let _ = ss.get_any_collection().await.unwrap();
     }
 
+    #[test_with::no_env(GITHUB_ACTIONS)]
     #[tokio::test]
     async fn should_create_and_delete_collection() {
         let ss = SecretService::connect(EncryptionType::Plain).await.unwrap();


### PR DESCRIPTION
While preparing my previous contribution I noticed that the CI doesn't run the tests, so I thought you might find this useful.