### PR TITLE
Add an option to use openssl for encryption instead of Rust crates

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,7 +46,7 @@ jobs:
     - uses: actions-rs/cargo@v1
       with:
         command: clippy
-        args: --feature=rt-async-io-crypto-rust --all-targets --all -- -D clippy::dbg_macro -D warnings -F unused_must_use
+        args: --features=rt-tokio-crypto-rust --all-targets --all -- -D clippy::dbg_macro -D warnings -F unused_must_use
 
   fmt:
     name: Rustfmt
@@ -98,12 +98,19 @@ jobs:
         # the login password doesn't matter, but the keyring must be unlocked for the tests to work
         run: gnome-keyring-daemon --components=secrets --daemonize --unlock <<< 'foobar'
 
-      - name: Run tests
+      - name: Run tests with rust crypto
         uses: actions-rs/cargo@v1
         with:
           command: test
           # run tests single-threaded to avoid race conditions
-          args: -- --test-threads=1
+          args: --features=rt-tokio-crypto-rust -- --test-threads=1
+
+      - name: Run tests with openssl crypto
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          # run tests single-threaded to avoid race conditions
+          args: --features=rt-tokio-crypto-openssl -- --test-threads=1
 
       - name: Run example
         uses: actions-rs/cargo@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,7 +46,7 @@ jobs:
     - uses: actions-rs/cargo@v1
       with:
         command: clippy
-        args: --all-features --all-targets --all -- -D clippy::dbg_macro -D warnings -F unused_must_use
+        args: --feature=rt-async-io-crypto-rust --all-targets --all -- -D clippy::dbg_macro -D warnings -F unused_must_use
 
   fmt:
     name: Rustfmt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,22 +13,26 @@ rust-version = "1.60.0"
 
 # The async runtime features mirror those of `zbus` for compatibility.
 [features]
-default = ["async-io"]
+default = ["async-io", "rs-crypto"]
 async-io = ["zbus/async-io"]
 tokio = ["zbus/tokio"]
+rs-crypto = ["dep:aes", "dep:block-modes", "dep:sha2", "dep:hkdf"]
+vendored-openssl = ["openssl", "openssl/vendored"]
 
 [dependencies]
 # TODO: Update these when Rust 1.56 isn't so new.
-aes = "0.7.0"
-block-modes = "0.8.0"
-hkdf = "0.12.0"
+aes = { version = "0.7.0", optional = true }
+block-modes = { version = "0.8.0", optional = true }
+hkdf = { version = "0.12.0", optional = true }
+generic-array = "0.14"
 once_cell = "1"
 futures-util = "0.3"
 num = "0.4.0"
 rand = "0.8.1"
 serde = { version = "1.0", features = ["derive"] }
-sha2 = "0.10.0"
+sha2 = { version = "0.10.0", optional = true }
 zbus = { version = "3", default-features = false }
+openssl = { version = "^0.10.40", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,14 @@ rust-version = "1.60.0"
 
 # The async runtime features mirror those of `zbus` for compatibility.
 [features]
-default = ["async-io", "rs-crypto"]
-async-io = ["zbus/async-io"]
-tokio = ["zbus/tokio"]
-rs-crypto = ["dep:aes", "dep:block-modes", "dep:sha2", "dep:hkdf"]
-vendored-openssl = ["openssl", "openssl/vendored"]
+crypto-rust = ["dep:aes", "dep:block-modes", "dep:sha2", "dep:hkdf"]
+crypto-openssl = ["dep:openssl"]
+
+rt-async-io-crypto-rust = ["zbus/async-io", "crypto-rust"]
+rt-async-io-crypto-openssl = ["zbus/async-io", "crypto-openssl"]
+
+rt-tokio-crypto-rust = ["zbus/tokio", "crypto-rust"]
+rt-tokio-crypto-openssl = ["zbus/tokio", "crypto-openssl"]
 
 [dependencies]
 # TODO: Update these when Rust 1.56 isn't so new.

--- a/src/session.rs
+++ b/src/session.rs
@@ -21,12 +21,7 @@ use crate::proxy::service::{OpenSessionResult, ServiceProxy, ServiceProxyBlockin
 use crate::ss::{ALGORITHM_DH, ALGORITHM_PLAIN};
 use crate::Error;
 
-use aes::cipher::consts::U16;
-use aes::cipher::generic_array::GenericArray;
-use aes::Aes128;
-use block_modes::block_padding::Pkcs7;
-use block_modes::{BlockMode, Cbc};
-use hkdf::Hkdf;
+use generic_array::{typenum::U16, GenericArray};
 use num::{
     bigint::BigUint,
     integer::Integer,
@@ -35,7 +30,6 @@ use num::{
 };
 use once_cell::sync::Lazy;
 use rand::{rngs::OsRng, Rng};
-use sha2::Sha256;
 use zbus::zvariant::OwnedObjectPath;
 
 use std::ops::{Mul, Rem, Shr};
@@ -97,20 +91,45 @@ impl Keypair {
         // input keying material
         let ikm = common_secret_padded;
         let salt = None;
-        let info = [];
 
         // output keying material
         let mut okm = [0; 16];
+        hkdf(ikm, salt, &mut okm);
 
-        let (_, hk) = Hkdf::<Sha256>::extract(salt, &ikm);
-        hk.expand(&info, &mut okm)
-            .expect("hkdf expand should never fail");
-
-        GenericArray::clone_from_slice(okm.as_slice())
+        GenericArray::clone_from_slice(&okm)
     }
 }
 
-type Aes128Cbc = Cbc<Aes128, Pkcs7>;
+#[cfg(feature = "openssl")]
+fn hkdf(ikm: Vec<u8>, salt: Option<&[u8]>, okm: &mut [u8]) {
+    let mut ctx = openssl::pkey_ctx::PkeyCtx::new_id(openssl::pkey::Id::HKDF)
+        .expect("hkdf context should not fail");
+    ctx.derive_init().expect("hkdf derive init should not fail");
+    ctx.set_hkdf_md(openssl::md::Md::sha256())
+        .expect("hkdf set md should not fail");
+
+    ctx.set_hkdf_key(&ikm)
+        .expect("hkdf set key should not fail");
+    if let Some(salt) = salt {
+        ctx.set_hkdf_salt(salt)
+            .expect("hkdf set salt should not fail");
+    }
+
+    ctx.add_hkdf_info(&[]).unwrap();
+    ctx.derive(Some(okm))
+        .expect("hkdf expand should never fail");
+}
+
+#[cfg(not(feature = "openssl"))]
+fn hkdf(ikm: Vec<u8>, salt: Option<&[u8]>, okm: &mut [u8]) {
+    use hkdf::Hkdf;
+    use sha2::Sha256;
+
+    let info = [];
+    let (_, hk) = Hkdf::<Sha256>::extract(salt, &ikm);
+    hk.expand(&info, okm)
+        .expect("hkdf expand should never fail");
+}
 
 pub struct Session {
     pub object_path: OwnedObjectPath,
@@ -207,18 +226,62 @@ fn powm(base: &BigUint, exp: &BigUint, modulus: &BigUint) -> BigUint {
     result
 }
 
+#[cfg(not(feature = "openssl"))]
 pub fn encrypt(data: &[u8], key: &AesKey, iv: &[u8]) -> Vec<u8> {
+    use aes::Aes128;
+    use block_modes::block_padding::Pkcs7;
+    use block_modes::{BlockMode, Cbc};
+
     let iv = GenericArray::from_slice(iv);
-    let cipher = Aes128Cbc::new_fix(key, iv);
+    let cipher = Cbc::<Aes128, Pkcs7>::new_fix(key, iv);
     cipher.encrypt_vec(data)
 }
 
+#[cfg(not(feature = "openssl"))]
 pub fn decrypt(encrypted_data: &[u8], key: &AesKey, iv: &[u8]) -> Result<Vec<u8>, Error> {
+    use aes::Aes128;
+    use block_modes::block_padding::Pkcs7;
+    use block_modes::{BlockMode, Cbc};
+
     let iv = GenericArray::from_slice(iv);
-    let cipher = Aes128Cbc::new_fix(key, iv);
+    let cipher = Cbc::<Aes128, Pkcs7>::new_fix(key, iv);
     cipher
         .decrypt_vec(encrypted_data)
         .map_err(|_| Error::Crypto("message decryption failed"))
+}
+
+#[cfg(feature = "openssl")]
+pub fn encrypt(data: &[u8], key: &AesKey, iv: &[u8]) -> Vec<u8> {
+    use openssl::cipher::Cipher;
+    use openssl::cipher_ctx::CipherCtx;
+
+    let mut ctx = CipherCtx::new().expect("cipher creation should not fail");
+    ctx.encrypt_init(Some(Cipher::aes_128_cbc()), Some(key), Some(iv))
+        .expect("cipher init should not fail");
+
+    let mut output = vec![];
+    ctx.cipher_update_vec(data, &mut output)
+        .expect("cipher update should not fail");
+    ctx.cipher_final_vec(&mut output)
+        .expect("cipher final should not fail");
+    output
+}
+
+#[cfg(feature = "openssl")]
+pub fn decrypt(encrypted_data: &[u8], key: &AesKey, iv: &[u8]) -> Result<Vec<u8>, Error> {
+    use openssl::cipher::Cipher;
+    use openssl::cipher_ctx::CipherCtx;
+
+    let mut ctx = CipherCtx::new().expect("cipher creation should not fail");
+    ctx.decrypt_init(Some(Cipher::aes_128_cbc()), Some(key), Some(iv))
+        .expect("cipher init should not fail");
+
+    let mut output = vec![];
+    ctx.cipher_update_vec(encrypted_data, &mut output)
+        .map_err(|_| Error::Crypto("message decryption failed"))?;
+    ctx.cipher_final_vec(&mut output)
+        .map_err(|_| Error::Crypto("message decryption failed"))?;
+    Ok(output)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR adds a flag and option to use openssl for encryption-related functionality instead of Rust crypto. This is useful when the consumer is required to be [FIPS](https://en.wikipedia.org/wiki/FIPS_140-3) compliant: essentially this means only use approved, NIST-signed libraries for doing encryption. With this change, a consumer can toggle default-features off and `openssl` on, then depend on a signed OpenSSL library, and be FIPS compliant. Unfortunately the flags here are a bit of a cludge without https://github.com/rust-lang/cargo/issues/1839

I realize this is not very large use case, or the nicest change ever--pure Rust is faster and more pleasant to build with 🙂--but I thought I would submit a PR and see what you think.