### PR TITLE
Improve runtime and crypto backend documentation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -116,4 +116,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: run
-          args: --example example
+          args: --features=rt-tokio-crypto-rust --example example

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 bin
 target
 Cargo.lock
+
+.vscode/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@ Unreleased
 - BREAKING: The `SecretService::new()` method was renamed to `SecretService::connect()` to be more accurate.
 - BREAKING: `Error` is now marked as `#[non_exhaustive]` to allow for additions to be made more easily in the future.
 - BREAKING: Several dead error variants were pruned.
-- BREAKING: `search_items` now returns both locked and unlocked items. If an unlocked item isn't present in the list, it must be unlocked
-manually.
+- BREAKING: `search_items` now returns both locked and unlocked items. If an unlocked item isn't present 
+in the list, it must be unlocked manually.
+- BREAKING: It is now required to choose a feature set in order to use the crate. See the README for more details.
 
 [2.0.2]
 - Increased minimum `zbus` version to 1.9.2, in order to increase the minimum version of the transitive dependency `nix` to at least 0.20.2, which is the first `nix` release to contain the fix for the security vulnerability described at https://rustsec.org/advisories/RUSTSEC-2021-0119 . A known issue with this version of `nix` is that it places an upper bound on the version of the `bitflags` dependency; if you are depending on `bitflags`, you may need to downgrade your `bitflags` version in order to upgrade to this version of `secret-service`, which you are encouraged to do in order to ensure that you are not exposed to the aforementioned `nix` vulnerability. In the long term, this will be fixed by upgrading `secret-service` to use a newer version of `zbus`, which itself depends on versions of `nix` which no longer have this restriction on `bitflags`.

--- a/README.md
+++ b/README.md
@@ -4,34 +4,35 @@ Secret Service Rust library.
 
 Interfaces with the Linux Secret Service API through dbus.
 
-### Versioning
-This library is feature complete, has stabilized its API for the most part. However, as this
-crate is almost soley reliable on the `zbus` crate, we try and match major version releases
-with theirs to handle breaking changes and move with the wider `zbus` ecosystem.
-
 ### Documentation
 
 [Get Docs!](https://docs.rs/secret-service/)
 
 ### Basic Usage
 
-Does not require dbus library! Pure Rust!
-(On ubuntu, this was libdbus-1-dev when building, and libdbus-1-3 when running)
+`secret-service` is implemented in pure Rust by default, so it doesn't require any system libraries
+such as `libdbus-1-dev` or `libdbus-1-3` on Ubuntu.
 
 In Cargo.toml:
 
-```
+When adding the crate, you must select a feature representing your selected runtime and cryptography backend. 
+For example:
+
+```toml
 [dependencies]
-secret-service = "2.0.0"
+secret-service = { version = "3.0.0", features = ["rt-tokio-crypto-rust"] }
 ```
 
-Or, you can add this project with `cargo add`:
+Available feature flags:
+- `rt-async-io-crypto-rust`: Uses the `async-std` runtime and pure Rust crytography via `RustCrypto`.
+- `rt-async-io-crypto-openssl`: Uses the `async-std` runtime and OpenSSL as the cryptography provider.
+- `rt-tokio-crypto-rust`: Uses the `tokio` runtime and pure Rust cryptography via `RustCrypto`.
+- `rt-tokio-crypto-openssl`: Uses the `tokio` runtime and OpenSSL as the cryptography provider.
 
-```
-$ cargo add secret-service
-```
+Note that the `-openssl` feature sets require OpenSSL to be available on your system, or the `bundled` feature
+of `openssl` crate must be activated in your `cargo` dependency tree instead.
 
-In source code (below example is for --bin, not --lib). This example uses `tokio` as
+In source code (below example is for `--bin`, not `--lib`). This example uses `tokio` as
 the async runtime.
 
 ```rust
@@ -81,6 +82,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
 ### Changelog
 See [the changelog file](./CHANGELOG.md)
+
+### Versioning
+This library is feature complete, has stabilized its API for the most part. However, as this
+crate is almost soley reliable on the `zbus` crate, we try and match major version releases
+with theirs to handle breaking changes and move with the wider `zbus` ecosystem.
 
 ## License
 

--- a/src/blocking/item.rs
+++ b/src/blocking/item.rs
@@ -234,14 +234,18 @@ mod test {
                 "text/plain",
             )
             .unwrap();
+
         let attributes = item.get_attributes().unwrap();
+
+        // We do not compare exact attributes, since the secret service provider could add its own
+        // at any time. Instead, we only check that the ones we provided are returned back.
         assert_eq!(
-            attributes,
-            HashMap::from([(
-                String::from("test_attributes_in_item"),
-                String::from("test")
-            )])
+            attributes
+                .get("test_attributes_in_item")
+                .map(String::as_str),
+            Some("test")
         );
+
         item.delete().unwrap();
     }
 
@@ -255,14 +259,18 @@ mod test {
         item.set_attributes(HashMap::new()).unwrap();
         item.set_attributes(HashMap::from([("test_attributes_in_item_get", "test")]))
             .unwrap();
+
         let attributes = item.get_attributes().unwrap();
+
+        // We do not compare exact attributes, since the secret service provider could add its own
+        // at any time. Instead, we only check that the ones we provided are returned back.
         assert_eq!(
-            attributes,
-            HashMap::from([(
-                String::from("test_attributes_in_item_get"),
-                String::from("test")
-            )])
+            attributes
+                .get("test_attributes_in_item_get")
+                .map(String::as_str),
+            Some("test")
         );
+
         item.delete().unwrap();
     }
 

--- a/src/item.rs
+++ b/src/item.rs
@@ -248,14 +248,18 @@ mod test {
             )
             .await
             .unwrap();
+
         let attributes = item.get_attributes().await.unwrap();
+
+        // We do not compare exact attributes, since the secret service provider could add its own
+        // at any time. Instead, we only check that the ones we provided are returned back.
         assert_eq!(
-            attributes,
-            HashMap::from([(
-                String::from("test_attributes_in_item"),
-                String::from("test")
-            )])
+            attributes
+                .get("test_attributes_in_item")
+                .map(String::as_str),
+            Some("test")
         );
+
         item.delete().await.unwrap();
     }
 
@@ -270,14 +274,18 @@ mod test {
         item.set_attributes(HashMap::from([("test_attributes_in_item_get", "test")]))
             .await
             .unwrap();
+
         let attributes = item.get_attributes().await.unwrap();
+
+        // We do not compare exact attributes, since the secret service provider could add its own
+        // at any time. Instead, we only check that the ones we provided are returned back.
         assert_eq!(
-            attributes,
-            HashMap::from([(
-                String::from("test_attributes_in_item_get"),
-                String::from("test")
-            )])
+            attributes
+                .get("test_attributes_in_item_get")
+                .map(String::as_str),
+            Some("test")
         );
+
         item.delete().await.unwrap();
     }
 


### PR DESCRIPTION
This PR follows up on https://github.com/hwchen/secret-service-rs/pull/58 by adding more documentation about the newly added feature sets. The intention is to make the happy path from a compilation error to working again faster with minimal project navigating required.

Additionally, these changes make CI green again.