### PR TITLE
Supply feature set to docs.rs during builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,3 +40,6 @@ openssl = { version = "^0.10.40", optional = true }
 [dev-dependencies]
 tokio = { version = "1", features = ["rt", "macros"] }
 test-with = { version = "0.8", default-features = false }
+
+[package.metadata.docs.rs]
+features = ["rt-tokio-crypto-rust"]


### PR DESCRIPTION
When we removed the default features in the 3.0 release, I missed the fact that `docs.rs` still requires some kind of "default feature" so that `secret-service`'s docs are able to build. Unlike regular users, the automated build system can't "follow the README." 

This PR tells `docs.rs` to build using Tokio and RustCrypto, but the feature used doesn't matter since it does not affect the public API.

Closes #65