### PR TITLE
Release 3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Unreleased
 
+[3.0.1]
+- Fix docs.rs builds
+
 [3.0.0]
 - Updated dependencies where reasonable
 - Bumped MSRV to 1.60
@@ -64,3 +67,4 @@ _0.1.0_
 [2.0.1]: https://github.com/hwchen/secret-service-rs/releases/tag/v2.0.1
 [2.0.2]: https://github.com/hwchen/secret-service-rs/releases/tag/v2.0.2
 [3.0.0]: https://github.com/hwchen/secret-service-rs/releases/tag/v3.0.0
+[3.0.1]: https://github.com/hwchen/secret-service-rs/releases/tag/v3.0.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 name = "secret-service"
 repository = "https://github.com/hwchen/secret-service-rs.git"
 edition = "2021"
-version = "3.0.0"
+version = "3.0.1"
 rust-version = "1.60.0"
 
 # The async runtime features mirror those of `zbus` for compatibility.


### PR DESCRIPTION
This should address the docs.rs build issues by giving it a fixed version to generate from instead.