### PR TITLE
Move MSRV testing to its own job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -85,6 +85,14 @@ jobs:
           toolchain: ${{ matrix.rust }}
           profile: minimal
 
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: $test-cache-${{ steps.toolchain.outputs.rustc_hash }}-${{ hashFiles('**/Cargo.lock') }}
+
       - name: Install gnome-keyring
         run: sudo apt-get install -y gnome-keyring
 
@@ -128,6 +136,14 @@ jobs:
         with:
           toolchain: "1.60.0"
           profile: minimal
+
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: $clippy-cache-${{ steps.toolchain.outputs.rustc_hash }}-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Generate lockfile
       # XXX: `0.6.1` of `toml_datetime` is the last version with a MSRV that matches

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,8 +20,6 @@ jobs:
       matrix:
         rust:
           - stable
-          # MSRV, influenced by zbus.
-          - 1.60.0
 
     steps:
     - uses: actions/checkout@v2
@@ -76,8 +74,6 @@ jobs:
       matrix:
         rust:
           - stable
-          # MSRV, influenced by zbus.
-          - 1.60.0
 
     steps:
       - uses: actions/checkout@v2
@@ -117,3 +113,31 @@ jobs:
         with:
           command: run
           args: --features=rt-tokio-crypto-rust --example example
+
+  # MSRV, influenced by zbus.
+  check_msrv:
+    name: Check MSRV
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: "1.60.0"
+          profile: minimal
+
+      - name: Generate lockfile
+      # XXX: `0.6.1` of `toml_datetime` is the last version with a MSRV that matches
+      # our current one. 
+        run: |
+          cargo generate-lockfile
+          cargo update -p toml_datetime --precise "0.6.1"
+
+      - uses: actions-rs/cargo@v1
+        name: Clippy MSRV
+        with:
+          command: clippy
+          args: --features=rt-tokio-crypto-rust --all-targets --all -- -D clippy::dbg_macro -D warnings -F unused_must_use


### PR DESCRIPTION
This PR hopefully fixes our current CI failures due to a dependency's MRSV going past our own, and makes dealing with future cases easier.

These approach taken was inspired by https://github.com/sfackler/rust-openssl/pull/1808.