### PR TITLE
Added unlock_all method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -326,6 +326,18 @@ impl<'a> SecretService<'a> {
                 .collect::<Result<_, _>>()?,
         })
     }
+
+    /// Unlock all items in a batch
+    pub async fn unlock_all(&self, items: &[&Item<'_>]) -> Result<(), Error> {
+        let objects = items.iter().map(|i| &*i.item_path).collect();
+        let lock_action_res = self.service_proxy.unlock(objects).await?;
+
+        if lock_action_res.object_paths.is_empty() {
+            exec_prompt(self.conn.clone(), &lock_action_res.prompt).await?;
+        }
+
+        Ok(())
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Hi,

This PR adds a new method to async `SecretService` and its blocking counterpart.

Motivation - some secret service implementations such as KeePassXc have a security setting that enables interactive unlocking by showing a notification that must be manually confirmed on unlock. With it set, when this crate is used to search for 10 secrets and unlock them in a loop via `item.unlock()` this leads to 10 interactive notifications. This PR makes it possible to unlock several secrets with a single interactive notification.
