### PR TITLE
Update RustCrypto dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ rust-version = "1.64.0"
 
 # The async runtime features mirror those of `zbus` for compatibility.
 [features]
-crypto-rust = ["dep:aes", "dep:block-modes", "dep:sha2", "dep:hkdf"]
+crypto-rust = ["dep:aes", "dep:cbc", "dep:sha2", "dep:hkdf"]
 crypto-openssl = ["dep:openssl"]
 
 rt-async-io-crypto-rust = ["zbus/async-io", "crypto-rust"]
@@ -23,9 +23,8 @@ rt-tokio-crypto-rust = ["zbus/tokio", "crypto-rust"]
 rt-tokio-crypto-openssl = ["zbus/tokio", "crypto-openssl"]
 
 [dependencies]
-# TODO: Update these when Rust 1.56 isn't so new.
-aes = { version = "0.7.0", optional = true }
-block-modes = { version = "0.8.0", optional = true }
+aes = { version = "0.8", optional = true }
+cbc = { version = "0.1", features = ["block-padding", "alloc"] , optional = true }
 hkdf = { version = "0.12.0", optional = true }
 generic-array = "0.14"
 once_cell = "1"

--- a/src/session.rs
+++ b/src/session.rs
@@ -240,25 +240,26 @@ fn powm(base: &BigUint, exp: &BigUint, modulus: &BigUint) -> BigUint {
 
 #[cfg(feature = "crypto-rust")]
 pub fn encrypt(data: &[u8], key: &AesKey, iv: &[u8]) -> Vec<u8> {
-    use aes::Aes128;
-    use block_modes::block_padding::Pkcs7;
-    use block_modes::{BlockMode, Cbc};
+    use aes::cipher::block_padding::Pkcs7;
+    use aes::cipher::{BlockEncryptMut, KeyIvInit};
+
+    type Aes128CbcEnc = cbc::Encryptor<aes::Aes128>;
 
     let iv = GenericArray::from_slice(iv);
-    let cipher = Cbc::<Aes128, Pkcs7>::new_fix(key, iv);
-    cipher.encrypt_vec(data)
+
+    Aes128CbcEnc::new(key, iv).encrypt_padded_vec_mut::<Pkcs7>(data)
 }
 
 #[cfg(feature = "crypto-rust")]
 pub fn decrypt(encrypted_data: &[u8], key: &AesKey, iv: &[u8]) -> Result<Vec<u8>, Error> {
-    use aes::Aes128;
-    use block_modes::block_padding::Pkcs7;
-    use block_modes::{BlockMode, Cbc};
+    use aes::cipher::block_padding::Pkcs7;
+    use aes::cipher::{BlockDecryptMut, KeyIvInit};
+
+    type Aes128CbcDec = cbc::Decryptor<aes::Aes128>;
 
     let iv = GenericArray::from_slice(iv);
-    let cipher = Cbc::<Aes128, Pkcs7>::new_fix(key, iv);
-    cipher
-        .decrypt_vec(encrypted_data)
+    Aes128CbcDec::new(key, iv)
+        .decrypt_padded_vec_mut::<Pkcs7>(encrypted_data)
         .map_err(|_| Error::Crypto("message decryption failed"))
 }
 


### PR DESCRIPTION
The `block-modes` crate is deprecated, so switch to `cbc` instead.