### PR TITLE
Release version 4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 name = "secret-service"
 repository = "https://github.com/hwchen/secret-service-rs.git"
 edition = "2021"
-version = "3.1.0"
+version = "4.0.0"
 rust-version = "1.75.0"
 
 # The async runtime features mirror those of `zbus` for compatibility.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Secret Service
 
-Secret Service Rust library.
+[![crates.io version](https://img.shields.io/crates/v/secret-service.svg)](https://crates.io/crates/secret-service)
+[![crate documentation](https://docs.rs/secret-service/badge.svg)](https://docs.rs/secret-service)
+![MSRV](https://img.shields.io/badge/rustc-1.75+-blue.svg)
+[![crates.io downloads](https://img.shields.io/crates/d/secret-service.svg)](https://crates.io/crates/secret-service)
+![CI](https://github.com/hwchen/secret-service-rs/workflows/CI/badge.svg)
 
-Interfaces with the Linux Secret Service API through dbus.
-
-### Documentation
-
-[Get Docs!](https://docs.rs/secret-service/)
+A rust library for interacting with the FreeDesktop Secret Service API through DBus.
 
 ### Basic Usage
 

--- a/justfile
+++ b/justfile
@@ -1,2 +1,0 @@
-test filter = '':
-    cargo watch -x 'test {{filter}} -- --test-threads=1'


### PR DESCRIPTION
This prepares a new major release to match with the new `zbus` 4.0 release.

The 3.0 release series will be maintained for bugfixes for a period via backports.

Finishes #71