### PR TITLE
Update zbus to v5

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -131,7 +131,7 @@ jobs:
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: "1.75.0"
+          toolchain: "1.77.0"
           components: clippy
 
       - uses: actions/cache@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ name = "secret-service"
 repository = "https://github.com/hwchen/secret-service-rs.git"
 edition = "2021"
 version = "4.0.0"
-rust-version = "1.75.0"
+rust-version = "1.77.0"
 
 # The async runtime features mirror those of `zbus` for compatibility.
 [features]
@@ -33,7 +33,7 @@ num = "0.4.0"
 rand = "0.8.1"
 serde = { version = "1.0.103", features = ["derive"] }
 sha2 = { version = "0.10.0", optional = true }
-zbus = { version = "4", default-features = false }
+zbus = { version = "5", default-features = false, features = [ "blocking-api" ] }
 openssl = { version = "^0.10.40", optional = true }
 
 [dev-dependencies]

--- a/src/blocking/collection.rs
+++ b/src/blocking/collection.rs
@@ -15,8 +15,8 @@ use crate::util::{exec_prompt_blocking, format_secret, lock_or_unlock_blocking, 
 
 use std::collections::HashMap;
 use zbus::{
+    proxy::CacheProperties,
     zvariant::{Dict, ObjectPath, OwnedObjectPath, Value},
-    CacheProperties,
 };
 
 // Collection struct.

--- a/src/blocking/item.rs
+++ b/src/blocking/item.rs
@@ -14,7 +14,7 @@ use crate::ss::SS_DBUS_NAME;
 use crate::util::{exec_prompt_blocking, format_secret, lock_or_unlock_blocking, LockAction};
 
 use std::collections::HashMap;
-use zbus::{zvariant::OwnedObjectPath, CacheProperties};
+use zbus::{proxy::CacheProperties, zvariant::OwnedObjectPath};
 
 pub struct Item<'a> {
     conn: zbus::blocking::Connection,

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -15,8 +15,8 @@ use crate::Item;
 
 use std::collections::HashMap;
 use zbus::{
+    proxy::CacheProperties,
     zvariant::{Dict, ObjectPath, OwnedObjectPath, Value},
-    CacheProperties,
 };
 
 // Collection struct.

--- a/src/item.rs
+++ b/src/item.rs
@@ -14,7 +14,7 @@ use crate::ss::SS_DBUS_NAME;
 use crate::util::{exec_prompt, format_secret, lock_or_unlock, LockAction};
 
 use std::collections::HashMap;
-use zbus::{zvariant::OwnedObjectPath, CacheProperties};
+use zbus::{proxy::CacheProperties, zvariant::OwnedObjectPath};
 
 pub struct Item<'a> {
     conn: zbus::Connection,

--- a/src/proxy/collection.rs
+++ b/src/proxy/collection.rs
@@ -22,7 +22,7 @@ use super::SecretStruct;
     interface = "org.freedesktop.Secret.Collection",
     default_service = "org.freedesktop.Secret.Collection"
 )]
-trait Collection {
+pub trait Collection {
     /// Returns prompt: ObjectPath
     fn delete(&self) -> zbus::Result<OwnedObjectPath>;
 

--- a/src/proxy/item.rs
+++ b/src/proxy/item.rs
@@ -19,7 +19,7 @@ use super::SecretStruct;
     interface = "org.freedesktop.Secret.Item",
     default_service = "org.freedesktop.Secret.Item"
 )]
-trait Item {
+pub trait Item {
     fn delete(&self) -> zbus::Result<OwnedObjectPath>;
 
     /// returns `Secret`

--- a/src/proxy/prompt.rs
+++ b/src/proxy/prompt.rs
@@ -18,7 +18,7 @@ use zbus::zvariant::Value;
     interface = "org.freedesktop.Secret.Prompt",
     default_service = "org.freedesktop.Secret.Prompt"
 )]
-trait Prompt {
+pub trait Prompt {
     fn prompt(&self, window_id: &str) -> zbus::Result<()>;
 
     fn dismiss(&self) -> zbus::Result<()>;

--- a/src/proxy/service.rs
+++ b/src/proxy/service.rs
@@ -22,7 +22,7 @@ use zbus::zvariant::{ObjectPath, OwnedObjectPath, OwnedValue, Type, Value};
     default_service = "org.freedesktop.secrets",
     default_path = "/org/freedesktop/secrets"
 )]
-trait Service {
+pub trait Service {
     fn open_session(&self, algorithm: &str, input: Value<'_>) -> zbus::Result<OpenSessionResult>;
 
     fn create_collection(

--- a/src/util.rs
+++ b/src/util.rs
@@ -21,8 +21,8 @@ use crate::ss::SS_DBUS_NAME;
 use futures_util::StreamExt;
 use rand::{rngs::OsRng, Rng};
 use zbus::{
+    proxy::CacheProperties,
     zvariant::{self, ObjectPath},
-    CacheProperties,
 };
 
 // Helper enum for locking


### PR DESCRIPTION
[zbus 5.0.0 release](https://github.com/dbus2/zbus/releases/tag/zbus-5.0.0)

Some fairly minor changes needed.

In zbus v5 the blocking API is feature-gated, so I wonder if the blocking secret service API should be similarly behind a feature?
