### PR TITLE
Fix trait import issue

### DIFF
--- a/src/blocking/item.rs
+++ b/src/blocking/item.rs
@@ -143,8 +143,8 @@ impl<'a> Item<'a> {
     }
 }
 
-impl<'a> Eq for Item<'a> {}
-impl<'a> PartialEq for Item<'a> {
+impl Eq for Item<'_> {}
+impl PartialEq for Item<'_> {
     fn eq(&self, other: &Item) -> bool {
         self.item_path == other.item_path
             && self.get_attributes().unwrap() == other.get_attributes().unwrap()

--- a/src/blocking/mod.rs
+++ b/src/blocking/mod.rs
@@ -43,7 +43,7 @@ pub struct SecretService<'a> {
     service_proxy: ServiceProxyBlocking<'a>,
 }
 
-impl<'a> SecretService<'a> {
+impl SecretService<'_> {
     /// Create a new `SecretService` instance
     pub fn connect(encryption: EncryptionType) -> Result<Self, Error> {
         let conn = zbus::blocking::Connection::session().map_err(util::handle_conn_error)?;

--- a/src/util.rs
+++ b/src/util.rs
@@ -18,8 +18,8 @@ use crate::session::encrypt;
 use crate::session::Session;
 use crate::ss::SS_DBUS_NAME;
 
+use futures_util::StreamExt;
 use rand::{rngs::OsRng, Rng};
-use zbus::export::ordered_stream::OrderedStreamExt;
 use zbus::{
     zvariant::{self, ObjectPath},
     CacheProperties,


### PR DESCRIPTION
In #50 I accidentally imported a stream-based trait from `zbus`'s private macro reexport module. At the time I didn't notice this, but I didn't even need `OrderedStream` in the first place. The single stream its used on is not composite, so there's no ordering requirements anyway. Given that, it can be simply replaced with a trait from the existing`futures_util` dependency.

Closes https://github.com/hwchen/secret-service-rs/issues/85