### PR TITLE
Simplify implementation of item equality

### DIFF
--- a/src/blocking/item.rs
+++ b/src/blocking/item.rs
@@ -147,7 +147,6 @@ impl Eq for Item<'_> {}
 impl PartialEq for Item<'_> {
     fn eq(&self, other: &Item) -> bool {
         self.item_path == other.item_path
-            && self.get_attributes().unwrap() == other.get_attributes().unwrap()
     }
 }
 

--- a/src/item.rs
+++ b/src/item.rs
@@ -151,15 +151,12 @@ impl<'a> Item<'a> {
     pub async fn get_modified(&self) -> Result<u64, Error> {
         Ok(self.item_proxy.modified().await?)
     }
+}
 
-    /// Returns if an item is equal to `other`.
-    ///
-    /// This is the equivalent of the `PartialEq` trait, but `async`.
-    pub async fn equal_to(&self, other: &Item<'_>) -> Result<bool, Error> {
-        let this_attrs = self.get_attributes().await?;
-        let other_attrs = other.get_attributes().await?;
-
-        Ok(self.item_path == other.item_path && this_attrs == other_attrs)
+impl Eq for Item<'_> {}
+impl PartialEq for Item<'_> {
+    fn eq(&self, other: &Item) -> bool {
+        self.item_path == other.item_path
     }
 }
 


### PR DESCRIPTION
As discussed in #82, the current implementation seems non-ideal because it, intentionally or not, compares item paths _and_ fetches their attributes at the same time once the paths are equal. Since all the fetching is done "just in time" and not from previously cached value on `Item`, these calls would always return the same attributes since the paths are also the same.

As this behavior has been in `master` for years now (seemingly without issue), it seems unlikely that anyone has run into the case where the path changes silently due to a provider change while an `Item` object is alive. If someone raises this issue later it can be evaluated then and fixed whenever the next major release of `zbus` comes out to accompany the breaking change required.

Additionally this PR takes advantage of the fact that the async `Item` implementation no longer needs to make calls via `.await` and implements `PartialEq` for the item instead to more closely match the `blocking` `Item` public API.

Closes #82 