### PR TITLE
Remove rand in favor of getrandom

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ generic-array = "0.14"
 once_cell = "1"
 futures-util = "0.3"
 num = "0.4.0"
-rand = "0.8.1"
+getrandom = "0.2"
 serde = { version = "1.0.103", features = ["derive"] }
 sha2 = { version = "0.10.0", optional = true }
 zbus = { version = "5", default-features = false, features = [ "blocking-api" ] }

--- a/src/session.rs
+++ b/src/session.rs
@@ -29,7 +29,6 @@ use num::{
     FromPrimitive,
 };
 use once_cell::sync::Lazy;
-use rand::{rngs::OsRng, Rng};
 use zbus::zvariant::OwnedObjectPath;
 
 use std::ops::{Mul, Rem, Shr};
@@ -72,9 +71,8 @@ struct Keypair {
 
 impl Keypair {
     fn generate() -> Self {
-        let mut rng = OsRng {};
         let mut private_key_bytes = [0; 128];
-        rng.fill(&mut private_key_bytes);
+        getrandom::getrandom(&mut private_key_bytes).expect("platform RNG failed");
 
         let private_key = BigUint::from_bytes_be(&private_key_bytes);
         let public_key = powm(&DH_GENERATOR, &private_key, &DH_PRIME);

--- a/src/util.rs
+++ b/src/util.rs
@@ -19,7 +19,6 @@ use crate::session::Session;
 use crate::ss::SS_DBUS_NAME;
 
 use futures_util::StreamExt;
-use rand::{rngs::OsRng, Rng};
 use zbus::{
     proxy::CacheProperties,
     zvariant::{self, ObjectPath},
@@ -77,9 +76,8 @@ pub(crate) fn format_secret(
     let content_type = content_type.to_owned();
 
     if let Some(session_key) = session.get_aes_key() {
-        let mut rng = OsRng {};
         let mut aes_iv = [0; 16];
-        rng.fill(&mut aes_iv);
+        getrandom::getrandom(&mut aes_iv).expect("platform RNG failed");
 
         let encrypted_secret = encrypt(secret, session_key, &aes_iv);
 


### PR DESCRIPTION
We never used any rand-specific functionality and this avoids a dependency that changes more often.