### PR TITLE
Update version and README for 5.1 release.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 name = "secret-service"
 repository = "https://github.com/hwchen/secret-service-rs.git"
 edition = "2021"
-version = "5.0.0"
+version = "5.1.0"
 rust-version = "1.77.0"
 
 # The async runtime features mirror those of `zbus` for compatibility.

--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
 ### Functionality
 
-- SecretService: initialize dbus, create plain/encrypted session.
-- Collections: create, delete, search.
-- Items: create, delete, search, get/set secret.
+- SecretService: initialize dbus or use existing connection, create plain/encrypted session.
+- Collections: create, delete, search, get-by-path.
+- Items: create, delete, search, get-by-path, get/set secret.
 
 ### Changelog
 See [the list of GitHub releases and their release notes](https://github.com/hwchen/secret-service-rs/releases)


### PR DESCRIPTION
Update version to 5.1.0.
Add reuse of connection and get-by-path blurbs to README.